### PR TITLE
Fixed a bug in texthelper.lua

### DIFF
--- a/texthelper.lua
+++ b/texthelper.lua
@@ -247,7 +247,7 @@ function createRowStrings(self,str,taghandlers)
 						piecewidth = font:getWidth(piecechunk)
 					end
 					local chunkObj = chunkClass(piecechunk, font, piecewidth, piecelen)
-					insert(chunkPieces,chunkObj)
+					table.insert(chunkPieces,chunkObj)
 					
 					insertRow(chunkPieces,grid,rowcount)
 					


### PR DESCRIPTION
The correct name for the function is table.insert. Tested it locally (though, not extensively) and it appears to work.
